### PR TITLE
Tag fix when publishing to npm

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Publish to NPM
         run: |
-              yarn config set '//registry.npmjs.org/:_authToken' "${NPMJS_ACCESS_TOKEN}"
-              yarn publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
+              yarn config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
+              yarn publish --verbose
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-vitest": "^0.2.6",
     "jsdom": "^22.1.0",
-    "prettier": "^3.0.0",
+    "prettier": "^2.8.8",
     "rollup": "^3.26.1",
     "typescript": "^5.1.6",
     "vitest": "^0.32.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wunderbar-network/mini-digital-sdk",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "SDK for back-end (Node) and front-end (TypeScript/JavaScript) applications, to send analytics events to Mini.Digital",
   "exports": {
     ".": {
@@ -48,8 +48,8 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-vitest": "^0.2.6",
     "jsdom": "^22.1.0",
-    "prettier": "^2.8.8",
-    "rollup": "^3.26.0",
+    "prettier": "^3.0.0",
+    "rollup": "^3.26.1",
     "typescript": "^5.1.6",
     "vitest": "^0.32.4",
     "vitest-fetch-mock": "^0.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,10 +1995,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
-  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^29.5.0:
   version "29.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,10 +1995,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
+  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
 
 pretty-format@^29.5.0:
   version "29.6.0"
@@ -2081,10 +2081,17 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rollup@^3.21.0, rollup@^3.26.0:
+rollup@^3.21.0:
   version "3.26.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.26.0.tgz#9f2e0316a4ca641911cefd8515c562a9124e6130"
   integrity sha512-YzJH0eunH2hr3knvF3i6IkLO/jTjAEwU4HoMUbQl4//Tnl3ou0e7P5SjxdDr8HQJdeUJShlbEHXrrnEHy1l7Yg==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+rollup@^3.26.1:
+  version "3.26.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.26.1.tgz#b375bf4b3cbb35bdca717e3cee2413894c469397"
+  integrity sha512-I5gJCSpSMr3U9wv4D5YA8g7w7cj3eaSDeo7t+JcaFQOmoOUBgu4K9iMp8k3EZnwbJrjQxUMSKxMyB8qEQzzaSg==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
Fixed:
- Publishing to `npm` applied the wrong tag, now applies `latest` tag